### PR TITLE
Create generator for image colored placeholder

### DIFF
--- a/app/src/main/kotlin/com/github/ramonrabello/kiphy/common/ui/util/ColoredPlaceholderGenerator.kt
+++ b/app/src/main/kotlin/com/github/ramonrabello/kiphy/common/ui/util/ColoredPlaceholderGenerator.kt
@@ -1,0 +1,29 @@
+package com.github.ramonrabello.kiphy.common.ui.util
+
+import android.content.Context
+import androidx.core.content.ContextCompat
+import com.github.ramonrabello.kiphy.R
+
+/**
+ * Utility that generates a colored placeholder
+ * to be used by images.
+ */
+object ColoredPlaceholderGenerator {
+
+    private val placeholderColors = arrayOf(
+            R.color.colorLightGreen,
+            R.color.colorLightBlue,
+            R.color.colorLightPurple,
+            R.color.colorLightRed,
+            R.color.colorLightYellow
+    )
+
+    /**
+     * Generates a random integer between 1..placeholderColors.size
+     * (inclusive), which represents the resId for the placeholder color.
+     */
+    fun generate(context: Context): Int {
+        val randomIndex = (1..placeholderColors.size).random()
+        return ContextCompat.getColor(context, placeholderColors[randomIndex - 1])
+    }
+}

--- a/app/src/main/kotlin/com/github/ramonrabello/kiphy/trends/TrendingAdapter.kt
+++ b/app/src/main/kotlin/com/github/ramonrabello/kiphy/trends/TrendingAdapter.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -14,8 +13,8 @@ import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.bumptech.glide.request.RequestOptions
 import com.github.ramonrabello.kiphy.R
 import com.github.ramonrabello.kiphy.common.extensions.slugfy
+import com.github.ramonrabello.kiphy.common.ui.util.ColoredPlaceholderGenerator
 import com.github.ramonrabello.kiphy.trends.model.DataResponse
-import java.util.*
 
 /**
  * Adapter for trending items.
@@ -30,7 +29,9 @@ class TrendingAdapter : RecyclerView.Adapter<TrendingAdapter.TrendingViewHolder>
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TrendingViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.trending_view_holder, parent, false)
+        val view = LayoutInflater.from(parent.context)
+                .inflate(R.layout.trending_view_holder,
+                        parent, false)
         return TrendingViewHolder(view)
     }
 
@@ -57,27 +58,16 @@ class TrendingAdapter : RecyclerView.Adapter<TrendingAdapter.TrendingViewHolder>
                 // TODO: handle on click event later on
             }
 
-            // region TODO: Create PlaceholderColorGenerator and following logic to it
-            val placeholderColors = arrayOf(
-                    R.color.colorLightGreen,
-                    R.color.colorLightBlue,
-                    R.color.colorLightPurple,
-                    R.color.colorLightRed,
-                    R.color.colorLightYellow
-            )
-
-            // choose random color to be the image placeholder
-            val randomIndex = Random().nextInt(placeholderColors.size + 1 - 1) + 1
-            // endregion TODO
-
             Glide.with(itemView.context)
                     .asGif()
                     .load(data.images.fixed_width.url)
                     .apply(RequestOptions()
                             .diskCacheStrategy(DiskCacheStrategy.NONE)
-                            .placeholder(ColorDrawable(ContextCompat.getColor(itemView.context, placeholderColors[randomIndex - 1])))
+                            .placeholder(ColorDrawable(
+                                    ColoredPlaceholderGenerator.generate(itemView.context)))
                             .centerCrop())
-                    .transition(DrawableTransitionOptions.withCrossFade(android.R.anim.fade_in, 300))
+                    .transition(DrawableTransitionOptions
+                            .withCrossFade(android.R.anim.fade_in, 250))
                     .into(gifImage)
             gitSlug.text = data.slug.slugfy()
         }


### PR DESCRIPTION
### Why the reason for this PR?
The `TrendingAdapter` was responsible to generate the image placeholder colors, which was not respecting the Single Responsibility principle of SOLID. Hence, the `ColoredPlaceholderGenerator` was created to embed all the generation logic.

### What changed on this PR?
- Create the `ColoredPlaceholderGenerator` object
- Update `TrendingAdapter` to call now `ColoredPlaceholderGenerator`